### PR TITLE
Add Docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+UHRR.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM alpine:latest
+MAINTAINER Niccolò Izzo <n@izzo.sh>
+
+ENV HAMLIB_VERSION '4.5.5'
+
+# Install dependencies
+RUN apk add --no-cache git \
+                       python3 \
+                       py3-pyalsaaudio \
+                       py3-numpy \
+                       py3-tornado \
+                       py3-pyserial \
+                       py3-pyaudio \
+                       py3-hamlib \
+                       py3-pip \
+                       librtlsdr \
+                       autoconf \
+                       automake \
+                       libtool \
+                       swig \
+                       alpine-sdk
+RUN apk add --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing py3-pam
+RUN pip3 install pyrtlsdr --break-system-packages
+
+# Build hamlib from source
+RUN mkdir /hamlib
+WORKDIR /hamlib
+RUN git clone https://github.com/Hamlib/Hamlib.git src
+RUN cd src && git checkout Hamlib-$HAMLIB_VERSION && ./bootstrap && mkdir ../build && cd ../build && \
+ ../src/configure --prefix=$HOME/hamlib-prefix    --disable-shared --enable-static    --without-cxx-binding --disable-winradio    CFLAGS="-g -O2 -fdata-sections -ffunction-sections"  LDFLAGS="-Wl,--gc-sections" && \
+ make -j4 &&  make install-strip && cd ../../
+
+# Copy UHRR source files from host dir
+RUN mkdir /uhrh
+WORKDIR /uhrh
+COPY . /uhrh
+RUN ls /uhrh
+
+# ENV PYTHONPATH=/usr/local/lib/python3.7/site-packages:$PYTHONPATH
+CMD ["./UHRR"]

--- a/UHRR.log
+++ b/UHRR.log
@@ -1,1 +1,0 @@
-2020-11-15 00:53:01.857765:Auth error for CallSign:pi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  uhrh:
+    build: .
+    container_name: uhrh
+    restart: always
+    devices:
+      - /dev/snd:/dev/snd
+      - /dev/ttyUSB0:/dev/ttyUSB0
+    ports:
+      - 8888:8888


### PR DESCRIPTION
With this Dockerfile and docker-compose.yml, users can deploy this service on any
docker-enabled system, including linux servers, laptops, NAS etc.
All they need to do is:
```
sudo apt update; sudo apt install docker
git clone https://github.com/F4HTB/Universal_HamRadio_Remote_HTML5 uhrh; cd uhrh
# Configure the docker-compose.yml to suit their needs, e.g. for port mapping or serial device forwarding
docker compose build; docker compose up -d
```