### PR TITLE
Fix mode switching by replacing rig_parse_mode with RIG_MODE_* mapping

### DIFF
--- a/UHRR
+++ b/UHRR
@@ -395,13 +395,27 @@ class TRXRIG:
 			print("Could not obtain the current frequency via Hamlib!")
 		return self.infos["FREQ"]
 		
-	def setMode(self,MODE):
+	def setMode(self, MODE):
+		mode_map = {
+			"CW": Hamlib.RIG_MODE_CW,
+			"CWR": Hamlib.RIG_MODE_CWR,
+			"AM": Hamlib.RIG_MODE_AM,
+			"FM": Hamlib.RIG_MODE_FM,
+			"USB": Hamlib.RIG_MODE_USB,
+			"LSB": Hamlib.RIG_MODE_LSB,
+		}
+
 		try:
-		    
-			self.rig.set_mode(Hamlib.rig_parse_mode(MODE))
+			mode_upper = MODE.strip().upper()
+			if mode_upper not in mode_map:
+				print(f"Unsupported mode: {MODE}")
+				return self.infos["MODE"]
+
+			self.rig.set_mode(mode_map[mode_upper])
 			self.getMode()
-		except:
-			print("Could not set the mode via Hamlib!")
+		except Exception as e:
+			print(f"Could not set the mode via Hamlib! {e}")
+
 		return self.infos["MODE"]
 		
 	def getMode(self):


### PR DESCRIPTION
Hi F4HTB,

while setting up a new [Docker container](https://github.com/N1RX/UHRH-Dockerized), I ran into an issue where `Hamlib.rig_parse_mode` wasn't available in the Python bindings.

This small change replaces it with a direct mapping to `Hamlib.RIG_MODE_*` constants. It fixes the issue for me and should make the code more robust across different environments.

Tested and working with all modes.

73 de DL3NW
